### PR TITLE
Bunch of changes:

### DIFF
--- a/Goopfile
+++ b/Goopfile
@@ -1,1 +1,3 @@
+github.com/500px/go-utils
 github.com/go-sql-driver/mysql
+github.com/ziutek/mymysql/godrv

--- a/Goopfile.lock
+++ b/Goopfile.lock
@@ -1,3 +1,4 @@
 github.com/500px/go-utils #6c8f260d25f9326c7f7442be769630a0e4ee0144
 github.com/go-sql-driver/mysql #71f003c6e927d2550713e7637affb769977ece78
 github.com/ziutek/mymysql/godrv #e5d54ebfda3f8a15e7b192b65c2aa10cb4fd7e04
+github.com/siddontang/go-mysql #1a1e7fd11cb6e2d7034f903a2a8b62c8aa47a170

--- a/Goopfile.lock
+++ b/Goopfile.lock
@@ -1,1 +1,3 @@
+github.com/500px/go-utils #6c8f260d25f9326c7f7442be769630a0e4ee0144
 github.com/go-sql-driver/mysql #71f003c6e927d2550713e7637affb769977ece78
+github.com/ziutek/mymysql/godrv #e5d54ebfda3f8a15e7b192b65c2aa10cb4fd7e04

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ default: build
 
 BIN=mysql-log-player
 BIN_x64=mysql-log-player-x64
+SPLITTER_BIN=splitter
+SPLITTER_BIN_x64=splitter-x64
 STAGE=production
 
 all: build build_x64
@@ -22,6 +24,12 @@ build: deps generate_version
 
 build_x64: deps generate_version
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 goop exec go build -o $(BIN_x64)
+
+splitter:
+	cd splitter; go build -o $(SPLITTER_BIN); cd -
+
+splitter_x86:
+	cd splitter; GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o $(SPLITTER_BIN_x64); cd -
 
 test: deps
 	goop exec go test ./...

--- a/conn/conn.go
+++ b/conn/conn.go
@@ -14,9 +14,20 @@ type DBOpener interface {
 	Open() (DBConn, error)
 }
 
-type DBConn interface {
+type QConn interface {
 	Query(string, ...interface{}) (Rows, error)
+}
+
+type DBConn interface {
+	Begin() (Tx, error)
+	QConn
 	Close() error
+}
+
+type Tx interface {
+	QConn
+	Commit() error
+	Rollback() error
 }
 
 type Rows interface {
@@ -25,5 +36,5 @@ type Rows interface {
 }
 
 type Row interface {
-	Int(string) (int32, error)
+	Int(string) (int, error)
 }

--- a/conn/conn.go
+++ b/conn/conn.go
@@ -1,0 +1,29 @@
+package conn
+
+
+import (
+	"errors"
+)
+
+var (
+	NoRowsError = errors.New("no rows")
+	NoColumnError = errors.New("no columns")
+)
+
+type DBOpener interface {
+	Open() (DBConn, error)
+}
+
+type DBConn interface {
+	Query(string, ...interface{}) (Rows, error)
+	Close() error
+}
+
+type Rows interface {
+	First() (Row, error)
+	Close() error
+}
+
+type Row interface {
+	Int(string) (int32, error)
+}

--- a/conn/conns.go
+++ b/conn/conns.go
@@ -1,0 +1,38 @@
+package conn
+
+import (
+	"sync"
+)
+
+type DBConns struct {
+	maxConnections int
+	made           int
+	conns          chan DBConn
+	dbOpener       DBOpener
+	lock           sync.Mutex
+}
+
+func NewDBConns(maxConnections int, dbOpener DBOpener) *DBConns {
+	return &DBConns{maxConnections, 0, make(chan DBConn, maxConnections), dbOpener, sync.Mutex{}}
+}
+
+func (dbs *DBConns) AcquireDB() (DBConn, error) {
+	select {
+	case db := <-dbs.conns:
+		return db, nil
+	default:
+	}
+
+	dbs.lock.Lock()
+	if dbs.made < dbs.maxConnections {
+		dbs.made++
+		dbs.lock.Unlock()
+		return dbs.dbOpener.Open()
+	}
+	dbs.lock.Unlock()
+	return <-dbs.conns, nil
+}
+
+func (dbs *DBConns) ReleaseDB(db DBConn) {
+	dbs.conns<- db
+}

--- a/conn/gomysql.go
+++ b/conn/gomysql.go
@@ -1,0 +1,80 @@
+package conn
+
+import (
+	"database/sql"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+type GoMySQLOpener struct {
+	driver         string
+	connectionInfo string
+}
+type GoMySQLConn struct { db *sql.DB }
+type GoMySQLRows struct { rows *sql.Rows }
+type GoMySQLRow  struct { row *sql.Rows }
+
+func NewGoMySQLOpener(driver string, connectionInfo string) DBOpener {
+	return GoMySQLOpener{
+		driver:         driver,
+		connectionInfo: connectionInfo,
+	}
+}
+
+func (g GoMySQLOpener) Open() (DBConn, error) {
+	db, err := sql.Open(g.driver, g.connectionInfo)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	return GoMySQLConn{db}, nil
+}
+
+func (c GoMySQLConn) Query(query string, params ...interface{}) (Rows, error) {
+	rows, err := c.db.Query(query, params...)
+	if err != nil {
+		return nil, err
+	}
+	return GoMySQLRows{rows}, nil
+}
+
+func (c GoMySQLConn) Close() error {
+	return c.db.Close()
+}
+
+func (rs GoMySQLRows) Close() error {
+	return rs.rows.Close()
+}
+
+func (rs GoMySQLRows) First() (Row, error) {
+	if !rs.rows.Next() {
+		return nil, NoRowsError
+	}
+	return GoMySQLRow{rs.rows}, nil
+}
+
+func (r GoMySQLRow) Int(name string) (int32, error) {
+	colNames, err := r.row.Columns()
+	if err != nil {
+		return 0, err
+	}
+	if len(colNames) == 0 {
+		return 0, NoColumnError
+	}
+
+	var intValue int32
+	values := make([]interface{}, len(colNames))
+	for i, colName := range colNames {
+		if colName == name {
+			values[i] = &intValue
+		} else {
+			var iface interface{}
+			values[i] = &iface
+		}
+	}
+	if err = r.row.Scan(values...); err != nil {
+		return 0, err
+	}
+	return intValue, nil
+}

--- a/conn/mymysql.go
+++ b/conn/mymysql.go
@@ -1,0 +1,79 @@
+package conn
+
+import (
+	"github.com/ziutek/mymysql/mysql"
+	_ "github.com/ziutek/mymysql/native"
+)
+
+type MyMySQLOpener struct {
+	hostPort string
+	user     string
+	pass     string
+	dbName   string
+}
+
+type MyMySQLConn struct {
+	conn mysql.Conn
+}
+
+type MyMySQLTx struct {
+	conn mysql.Transaction
+}
+
+type MyMySQLRows struct {
+	rows mysql.Result
+}
+
+type MyMySQLRow  struct {
+	rows mysql.Result
+	row mysql.Row
+}
+
+func NewMyMySQLOpener(hostPort string, user, pass string, dbName string) *MyMySQLOpener {
+	return &MyMySQLOpener{
+		hostPort: hostPort,
+		user:     user,
+		pass:     pass,
+		dbName:   dbName,
+	}
+}
+
+func (m *MyMySQLOpener) Open() (DBConn, error) {
+	conn := mysql.New("tcp", "", m.hostPort, m.user, m.pass, m.dbName)
+	err := conn.Connect()
+	return &MyMySQLConn{conn}, err
+}
+
+func (c MyMySQLConn) Query(query string, args ...interface{}) (Rows, error) {
+	_, result, err := c.conn.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return &MyMySQLRows{result}, nil
+}
+
+func (c MyMySQLConn) Close() error {
+	return c.conn.Close()
+}
+
+func (rs MyMySQLRows) Close() error {
+	return nil
+}
+
+func (rs MyMySQLRows) First() (Row, error) {
+	row, err := rs.rows.GetFirstRow()
+	if err != nil {
+		return nil, err
+	}
+	return &MyMySQLRow{rs.rows, row}, nil
+}
+
+func (r MyMySQLRow) Int(name string) (int32, error) {
+	for i, field := range r.rows.Fields() {
+		if field.Name == name {
+			intValue := r.row.Int(i)
+			return int32(intValue), nil
+		}
+	}
+	return 0, NoColumnError
+}

--- a/conn/siddontang.go
+++ b/conn/siddontang.go
@@ -1,0 +1,73 @@
+package conn
+
+import (
+	"github.com/siddontang/go-mysql/client"
+	"github.com/siddontang/go-mysql/mysql"
+	"github.com/500px/go-utils/chatty_logger"
+)
+
+type SiddontangOpener struct {
+	hostPort string
+	user     string
+	pass     string
+	dbName   string
+}
+
+type SiddontangConn struct {
+	conn *client.Conn
+}
+
+type SiddontangRows struct {
+	result *mysql.Result
+}
+
+type SiddontangRow  struct {
+	result *mysql.Result
+}
+
+func NewSiddontangOpener(hostPort string, user, pass string, dbName string) *SiddontangOpener {
+	return &SiddontangOpener{
+		hostPort: hostPort,
+		user:     user,
+		pass:     pass,
+		dbName:   dbName,
+	}
+}
+
+func (m *SiddontangOpener) Open() (DBConn, error) {
+	conn, err := client.Connect(m.hostPort, m.user, m.pass, m.dbName)
+	logger.Debugf("Error connecting with (%v, %v, %v, %v)", m.hostPort, m.user, m.pass, m.dbName)
+	if err != nil {
+		return nil, err
+	}
+	return SiddontangConn{conn}, nil
+}
+
+func (c SiddontangConn) Query(query string, args ...interface{}) (Rows, error) {
+	result, err := c.conn.Execute(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return &SiddontangRows{result}, nil
+}
+
+func (c SiddontangConn) Close() error {
+	return c.conn.Close()
+}
+
+func (rs SiddontangRows) Close() error {
+	return nil
+}
+
+func (rs SiddontangRows) First() (Row, error) {
+	return &SiddontangRow{rs.result}, nil
+}
+
+func (r SiddontangRow) Int(name string) (int32, error) {
+	logger.Infof("SiddontangRow.Int(%s): status = %v", name, r.result.Status)
+	valInt64, err := r.result.GetIntByName(0, name)
+	if err != nil {
+		return 0, err
+	}
+	return int32(valInt64), nil
+}

--- a/flags.go
+++ b/flags.go
@@ -10,15 +10,17 @@ import (
 )
 
 var (
-	dbHost       = flag.String("db-host", "127.0.0.1", "MySQL host")
-	dbName       = flag.String("db-name", "500px", "MySQL database name")
-	dbUser       = flag.String("db-user", os.Getenv("DB_USER"), "MySQL username (env DB_USER)")
-	dbPass       = flag.String("db-pass", "", "MySQL password (env DB_PASS)")
-	logLevel     = logger.LogSeverity("log", logger.INFO, "The log level to emit.")
-	printVersion = flag.Bool("version", false, "Print version information and exit.")
+	dbHost        = flag.String("db-host", "127.0.0.1", "MySQL host")
+	dbName        = flag.String("db-name", "500px", "MySQL database name")
+	dbUser        = flag.String("db-user", os.Getenv("DB_USER"), "MySQL username (env DB_USER)")
+	dbPass        = flag.String("db-pass", "", "MySQL password (env DB_PASS)")
+	dbConcurrency = flag.Int("db-concurrency", 1500, "Number of concurrent queries.")
+	logLevel      = logger.LogSeverity("log", logger.INFO, "The log level to emit.")
+	printVersion  = flag.Bool("version", false, "Print version information and exit.")
 
-	sourcePath  = flag.String("source", "", "Path of input log or empty for stdin.")
-	workerCount = flag.Int("workers", 5, "Number of query workers.")
+	sourcePath    = flag.String("source", "vc-data/20160317-13.gz", "Path of input log .gz or empty for stdin.")
+	replaySpeed   = flag.Float64("replay-speed", 2.0, "replay speed 2.0 means twice as fast (half the time)")
+	workerCount   = flag.Int("workers", 5, "Number of query workers.")
 )
 
 func parseFlags() {

--- a/flags.go
+++ b/flags.go
@@ -5,9 +5,15 @@ import (
 	"os"
 
 	logger "github.com/500px/go-utils/chatty_logger"
+	"github.com/500px/go-utils/flags"
+	"fmt"
 )
 
 var (
+	dbHost       = flag.String("db-host", "127.0.0.1", "MySQL host")
+	dbName       = flag.String("db-name", "500px", "MySQL database name")
+	dbUser       = flag.String("db-user", os.Getenv("DB_USER"), "MySQL username (env DB_USER)")
+	dbPass       = flag.String("db-pass", "", "MySQL password (env DB_PASS)")
 	logLevel     = logger.LogSeverity("log", logger.INFO, "The log level to emit.")
 	printVersion = flag.Bool("version", false, "Print version information and exit.")
 
@@ -16,11 +22,22 @@ var (
 )
 
 func parseFlags() {
+	flags.SetFromEnv("db-user", "DB_USER")
+	flags.SetFromEnv("db-pass", "DB_PASS")
+
 	flag.Parse()
 	logger.Init(*logLevel)
 
 	if *printVersion {
 		version()
 		os.Exit(0)
+	}
+
+	if *dbUser == "" || *dbPass == "" {
+		fmt.Println("Both db-user and db-pass (env DB_USER and DB_PASS) are required; for no password use \"''\"")
+		os.Exit(1)
+	}
+	if *dbPass == "''" {
+		*dbPass = ""
 	}
 }

--- a/main.go
+++ b/main.go
@@ -9,8 +9,8 @@ import (
 
 	logger "github.com/500px/go-utils/chatty_logger"
 	// _ "github.com/go-sql-driver/mysql"
-	"github.com/500px/mysql-log-player/query"
-	"github.com/500px/mysql-log-player/worker"
+	"github.com/Melraidin/mysql-log-player/query"
+	"github.com/Melraidin/mysql-log-player/worker"
 )
 
 func main() {

--- a/query/query.go
+++ b/query/query.go
@@ -1,6 +1,9 @@
 package query
 
+import "time"
+
 type Query struct {
+	Time   time.Time
 	Client string
 	SQL    string
 }

--- a/query/query_reader.go
+++ b/query/query_reader.go
@@ -73,6 +73,7 @@ func (r *Reader) Read() (*Query, error) {
 			if matches := clientRegex.FindStringSubmatch(line); len(matches) == 2 {
 				query.Client = matches[1]
 			}
+		} else if strings.HasPrefix(line, "# Query_time: ") {
 		} else {
 			r.buffer.WriteString(line)
 		}

--- a/semaphore/semaphore.go
+++ b/semaphore/semaphore.go
@@ -1,0 +1,37 @@
+package semaphore
+
+import (
+	"sync"
+)
+
+type Semaphore struct {
+	cond sync.Cond
+	count int
+}
+
+func NewSemaphore(n uint) *Semaphore {
+	return &Semaphore{
+		cond: sync.Cond{L: &sync.Mutex{}},
+	}
+}
+
+func (s *Semaphore) Acquire() {
+	return
+	defer s.cond.L.Unlock()
+	s.cond.L.Lock()
+	for {
+		if s.count > 0 {
+			s.count -= 1
+			return
+		}
+		s.cond.Wait()
+	}
+}
+
+func (s *Semaphore) Release() {
+	return
+	defer s.cond.L.Unlock()
+	s.cond.L.Lock()
+	s.count += 1
+	s.cond.Signal()
+}

--- a/splitter/splitter.go
+++ b/splitter/splitter.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bufio"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+)
+
+func main() {
+	runtime.GOMAXPROCS(1)
+
+	reader := bufio.NewReader(os.Stdin)
+	filename := "19700101-00"; ext := ".gz"
+	var f *os.File
+	var bw *bufio.Writer
+	var writer *gzip.Writer
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			close(writer, bw, f)
+
+			if err == io.EOF {
+				os.Exit(0)
+			}
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
+		if strings.HasPrefix(line, "# Time: ") {
+			mmddyy_hh_mm := line[8:]
+			dateHour := fmt.Sprintf("20%s%s%s-%s", mmddyy_hh_mm[4:6], mmddyy_hh_mm[:2], mmddyy_hh_mm[2:4], mmddyy_hh_mm[7:9])
+			if dateHour > filename {
+				close(writer, bw, f)
+
+				filename = dateHour
+
+				err = open(filename + ext, &f, &bw, &writer)
+				exitOnError(err, writer, bw, f)
+			}
+		}
+		writer.Write([]byte(line))
+	}
+}
+
+func open(filename string, f **os.File, bw **bufio.Writer, writer **gzip.Writer) (err error) {
+	if *f, err = os.Create(filename); err != nil {
+		return
+	}
+	*bw = bufio.NewWriter(*f)
+	*writer, err = gzip.NewWriterLevel(*bw, gzip.BestCompression)
+	return
+}
+
+func close(writer *gzip.Writer, bw *bufio.Writer, f *os.File) {
+	if writer != nil {
+		writer.Close()
+	}
+	if bw != nil {
+		bw.Flush()
+	}
+	if f != nil {
+		f.Close()
+	}
+}
+
+func exitOnError(err error, writer *gzip.Writer, bw *bufio.Writer, f *os.File) {
+	if err != nil {
+		close(writer, bw, f)
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/worker/app_stats.go
+++ b/worker/app_stats.go
@@ -19,6 +19,8 @@ type AppStats struct {
 func NewAppStats(stats chan Stat, statsdClient metrics.StatsdClient) *AppStats {
 	return &AppStats{
 		stats:        stats,
+		userIds:      map[int32]struct{}{},
+		photoIds:     map[int32]struct{}{},
 		statsdClient: statsdClient,
 	}
 }

--- a/worker/app_stats.go
+++ b/worker/app_stats.go
@@ -1,0 +1,37 @@
+package worker
+
+import (
+	"github.com/500px/go-utils/metrics"
+)
+
+type Stat struct {
+	userId  int32
+    photoId int32
+}
+
+type AppStats struct {
+	stats        chan Stat
+	userIds      map[int32]struct{}
+	photoIds     map[int32]struct{}
+	statsdClient metrics.StatsdClient
+}
+
+func NewAppStats(stats chan Stat, statsdClient metrics.StatsdClient) *AppStats {
+	return &AppStats{
+		stats:        stats,
+		statsdClient: statsdClient,
+	}
+}
+
+func (a AppStats) Run() {
+	for stat := range a.stats {
+		if stat.userId > 0 {
+			a.userIds[stat.userId] = struct{}{}
+			a.statsdClient.Gauge("number.user_ids", float64(len(a.userIds)))
+		}
+		if stat.photoId > 0 {
+			a.photoIds[stat.photoId] = struct{}{}
+			a.statsdClient.Gauge("number.photo_ids", float64(len(a.photoIds)))
+		}
+	}
+}

--- a/worker/app_stats.go
+++ b/worker/app_stats.go
@@ -2,6 +2,8 @@ package worker
 
 import (
 	"github.com/500px/go-utils/metrics"
+	"time"
+	"fmt"
 )
 
 type Stat struct {
@@ -10,11 +12,17 @@ type Stat struct {
 }
 
 type AppStats struct {
+	start        time.Time
+	first        time.Time
 	stats        chan Stat
 	userIds      map[int32]struct{}
 	photoIds     map[int32]struct{}
 	statsdClient metrics.StatsdClient
 }
+
+var (
+	zeroTime = time.Time{}
+)
 
 func NewAppStats(stats chan Stat, statsdClient metrics.StatsdClient) *AppStats {
 	return &AppStats{
@@ -25,8 +33,22 @@ func NewAppStats(stats chan Stat, statsdClient metrics.StatsdClient) *AppStats {
 	}
 }
 
+func (a AppStats) ReportSpeed(t time.Time) {
+	if a.first == zeroTime {
+		a.start = time.Now().UTC()
+		a.first = t
+	} else {
+		elapsed := time.Now().Unix() - a.start.Unix()
+		replayed := t.Unix() - a.first.Unix()
+		if elapsed > 0 && replayed > 0 {
+			a.statsdClient.Gauge("replay-speed", float64(replayed) / float64(elapsed))
+		}
+	}
+}
+
 func (a AppStats) Run() {
 	for stat := range a.stats {
+		fmt.Printf("Stat: %v\n", stat)
 		if stat.userId > 0 {
 			a.userIds[stat.userId] = struct{}{}
 			a.statsdClient.Gauge("number.user_ids", float64(len(a.userIds)))

--- a/worker/app_stats.go
+++ b/worker/app_stats.go
@@ -1,22 +1,21 @@
 package worker
 
 import (
-	"github.com/500px/go-utils/metrics"
 	"time"
-	"fmt"
+	"github.com/500px/go-utils/metrics"
 )
 
 type Stat struct {
-	userId  int32
-    photoId int32
+	userId  int
+    photoId int
 }
 
 type AppStats struct {
 	start        time.Time
 	first        time.Time
 	stats        chan Stat
-	userIds      map[int32]struct{}
-	photoIds     map[int32]struct{}
+	userIds      map[int]struct{}
+	photoIds     map[int]struct{}
 	statsdClient metrics.StatsdClient
 }
 
@@ -27,8 +26,8 @@ var (
 func NewAppStats(stats chan Stat, statsdClient metrics.StatsdClient) *AppStats {
 	return &AppStats{
 		stats:        stats,
-		userIds:      map[int32]struct{}{},
-		photoIds:     map[int32]struct{}{},
+		userIds:      map[int]struct{}{},
+		photoIds:     map[int]struct{}{},
 		statsdClient: statsdClient,
 	}
 }
@@ -48,7 +47,6 @@ func (a AppStats) ReportSpeed(t time.Time) {
 
 func (a AppStats) Run() {
 	for stat := range a.stats {
-		fmt.Printf("Stat: %v\n", stat)
 		if stat.userId > 0 {
 			a.userIds[stat.userId] = struct{}{}
 			a.statsdClient.Gauge("number.user_ids", float64(len(a.userIds)))

--- a/worker/pool.go
+++ b/worker/pool.go
@@ -20,7 +20,7 @@ type WorkerPool struct {
 func NewWorkerPool(db *sql.DB, metrics metrics.StatsdClient) *WorkerPool {
 	stats := make(chan Stat, 2000)
 	appStats := NewAppStats(stats, metrics)
-	appStats.Run()
+	go appStats.Run()
 
 	return &WorkerPool{
 		db:          db,

--- a/worker/pool.go
+++ b/worker/pool.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	logger "github.com/500px/go-utils/chatty_logger"
-	"github.com/500px/mysql-log-player/query"
+	"github.com/Melraidin/mysql-log-player/query"
 )
 
 type WorkerPool struct {

--- a/worker/pool.go
+++ b/worker/pool.go
@@ -1,31 +1,72 @@
 package worker
 
 import (
-	"database/sql"
+	"fmt"
 	"sync"
+	"time"
 
 	logger "github.com/500px/go-utils/chatty_logger"
 	"github.com/500px/go-utils/metrics"
+	"github.com/melraidin/mysql-log-player/conn"
 	"github.com/melraidin/mysql-log-player/query"
 )
 
+type Concurrency struct {
+	limit int
+	count int
+	cond  *sync.Cond
+}
+
+func (c *Concurrency) Inc() int {
+	defer c.cond.L.Unlock()
+	c.cond.L.Lock()
+
+	waiting := false
+	for c.count >= c.limit {
+		if !waiting {
+			waiting = true
+			fmt.Printf("Concurrency: waiting...")
+		}
+		c.cond.Wait()
+	}
+	if waiting {
+		fmt.Printf("Concurrency: .")
+	}
+	c.count += 1
+	return c.count
+}
+
+func (c *Concurrency) Dec() int {
+	defer c.cond.L.Unlock()
+	c.cond.L.Lock()
+
+	c.count -= 1
+	c.cond.Broadcast()
+	return c.count
+}
+
 type WorkerPool struct {
-	db          *sql.DB
+	Logtime0    time.Time
+	Runtime0    time.Time
+	ReplaySpeed float64
+	dbConns     *conn.DBConns
 	wg          *sync.WaitGroup
-	connections map[string]chan<- string
+	concurrency *Concurrency
+	connections map[string]chan<- query.Query
 	appStats    *AppStats
 	metrics     metrics.StatsdClient
 }
 
-func NewWorkerPool(db *sql.DB, metrics metrics.StatsdClient) *WorkerPool {
+func NewWorkerPool(dbOpener conn.DBOpener, limit int, metrics metrics.StatsdClient) *WorkerPool {
 	stats := make(chan Stat, 2000)
 	appStats := NewAppStats(stats, metrics)
 	go appStats.Run()
 
 	return &WorkerPool{
-		db:          db,
+		dbConns:     conn.NewDBConns(limit, dbOpener),
 		wg:          &sync.WaitGroup{},
-		connections: make(map[string]chan<- string),
+		concurrency: &Concurrency{limit, 0, sync.NewCond(&sync.Mutex{})},
+		connections: make(map[string]chan<- query.Query),
 		appStats:    appStats,
 		metrics:     metrics,
 	}
@@ -35,11 +76,19 @@ func (p *WorkerPool) Dispatch(q *query.Query) {
 	workerChan, ok := p.connections[q.Client]
 	if !ok {
 		logger.Infof("Created new worker for client: %s", q.Client)
-		workerChan = NewWorker(q.Client, p.db, p.wg, p.appStats.stats, p.metrics)
+		workerChan = NewWorker(q.Client, p.Logtime0, p.Runtime0, p.ReplaySpeed, p.dbConns, p.wg, p.appStats.stats, p.metrics)
 		p.connections[q.Client] = workerChan
 		p.metrics.Gauge("clients", float64(len(p.connections)))
 	}
-	workerChan <- q.SQL
+	workerChan <- *q
+	p.appStats.ReportSpeed(q.Time)
+}
+
+func (p *WorkerPool) Close(client string) {
+	if workerChan, ok := p.connections[client]; ok {
+	        delete(p.connections, client)
+	        close(workerChan)
+        }
 }
 
 func (p *WorkerPool) Wait() {

--- a/worker/query_worker.go
+++ b/worker/query_worker.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 	"sync/atomic"
 	"github.com/500px/go-utils/metrics"
+	"errors"
 )
 
 var (
 	// Size of command buffer for new workers.
 	BufferSize = 20
 	concurrent = int64(0)
+	NoColumnError = errors.New("no columns")
 )
 
 type Worker struct {
@@ -64,7 +66,7 @@ func (w *Worker) Run() {
 		if err != nil {
 			w.metrics.Histogram("query.duration", float64(timer.Ms()), "status:error")
 			w.metrics.Incr("query.count", 1, "status:error")
-			logger.Warnf("error '%v' running query: %s", err, query)
+			logger.Debugf("error '%v' running query: %s", err, query)
 			continue
 		}
 		w.metrics.Histogram("query.duration", float64(timer.Ms()), "status:ok")
@@ -73,22 +75,55 @@ func (w *Worker) Run() {
 		if rows.Next() {
 			if strings.HasPrefix(query, "SELECT  `users`.* FROM `users` WHERE `users`.`authentication_token` =") {
 				stat := Stat{}
-				if err = rows.Scan(&stat.userId); err == nil {
+				if err = extractIntColumn(rows, "id", &stat.userId); err != nil {
+					logger.Debugf("Error extracting user 'id': %v", err)
+				} else {
 					w.stats <- stat
 				}
 			} else if strings.HasPrefix(query, "SELECT  `oauth_tokens`.* FROM `oauth_tokens` WHERE `oauth_tokens`.`type` IN ('Oauth2Token')") {
-				var id int32
 				stat := Stat{}
-				if err = rows.Scan(&id, &stat.userId); err == nil {
+				if err = extractIntColumn(rows, "user_id", &stat.userId); err != nil {
+					logger.Debugf("Error extracting 'user_id': %v", err)
+				} else {
+					w.stats <- stat
+				}
+			} else if strings.HasPrefix(query, "SELECT  `photos`.* FROM `photos` WHERE `photos`.`id` = ") {
+				stat := Stat{}
+				if err = extractIntColumn(rows, "id", &stat.photoId); err != nil {
+					logger.Debugf("Error extracting photo 'id': %v", err)
+				} else {
 					w.stats <- stat
 				}
 			}
 		}
-
 		err = rows.Close()
 		if err != nil {
 			logger.Warnf("error closing rows: %v", err)
 		}
 	}
 	w.wg.Done()
+}
+
+func extractIntColumn(rows *sql.Rows, name string, val *int32) error {
+	colNames, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+	if len(colNames) == 0 {
+		return NoColumnError
+	}
+
+	values := make([]interface{}, len(colNames))
+	for i, colName := range colNames {
+		if colName == name {
+			values[i] = val
+		} else {
+			var iface interface{}
+			values[i] = &iface
+		}
+	}
+	if err = rows.Scan(values...); err != nil {
+		return err
+	}
+	return nil
 }

--- a/worker/query_worker.go
+++ b/worker/query_worker.go
@@ -6,11 +6,14 @@ import (
 	logger "github.com/500px/go-utils/chatty_logger"
 	"database/sql"
 	"strings"
+	"sync/atomic"
+	"github.com/500px/go-utils/metrics"
 )
 
 var (
 	// Size of command buffer for new workers.
 	BufferSize = 20
+	concurrent = int64(0)
 )
 
 type Worker struct {
@@ -18,9 +21,11 @@ type Worker struct {
 	queryChan <-chan string
 	db        *sql.DB
 	wg        *sync.WaitGroup
+	stats     chan<- Stat
+	metrics   metrics.StatsdClient
 }
 
-func NewWorker(client string, db *sql.DB, wg *sync.WaitGroup) chan<- string {
+func NewWorker(client string, db *sql.DB, wg *sync.WaitGroup, stats chan<- Stat, metrics metrics.StatsdClient) chan<- string {
 	queryChan := make(chan string, BufferSize)
 
 	worker := Worker{
@@ -28,6 +33,8 @@ func NewWorker(client string, db *sql.DB, wg *sync.WaitGroup) chan<- string {
 		queryChan: queryChan,
 		db:        db,
 		wg:        wg,
+		stats:     stats,
+		metrics:   metrics,
 	}
 
 	wg.Add(1)
@@ -43,13 +50,41 @@ func (w *Worker) Run() {
 			logger.Debugf("[%s] Skipping non-SELECT query: %v", w.client, query)
 			continue
 		}
+
+		active := atomic.AddInt64(&concurrent, 1)
+		w.metrics.Gauge("query_worker.concurrent", float64(active))
 		logger.Debugf("[%s] Querying: %s", w.client, query)
 
+		timer := metrics.NewStopwatch()
 		rows, err := w.db.Query(query)
+		timer.Stop()
+
+		atomic.AddInt64(&concurrent, -1)
+		logger.Debugf("[%s] Queryed", w.client)
 		if err != nil {
+			w.metrics.Histogram("query.duration", float64(timer.Ms()), "status:error")
+			w.metrics.Incr("query.count", 1, "status:error")
 			logger.Warnf("error '%v' running query: %s", err, query)
 			continue
 		}
+		w.metrics.Histogram("query.duration", float64(timer.Ms()), "status:ok")
+		w.metrics.Incr("query.count", 1, "status:ok")
+
+		if rows.Next() {
+			if strings.HasPrefix(query, "SELECT  `users`.* FROM `users` WHERE `users`.`authentication_token` =") {
+				stat := Stat{}
+				if err = rows.Scan(&stat.userId); err == nil {
+					w.stats <- stat
+				}
+			} else if strings.HasPrefix(query, "SELECT  `oauth_tokens`.* FROM `oauth_tokens` WHERE `oauth_tokens`.`type` IN ('Oauth2Token')") {
+				var id int32
+				stat := Stat{}
+				if err = rows.Scan(&id, &stat.userId); err == nil {
+					w.stats <- stat
+				}
+			}
+		}
+
 		err = rows.Close()
 		if err != nil {
 			logger.Warnf("error closing rows: %v", err)

--- a/worker/query_worker.go
+++ b/worker/query_worker.go
@@ -1,129 +1,178 @@
 package worker
 
 import (
-	"sync"
-
-	logger "github.com/500px/go-utils/chatty_logger"
-	"database/sql"
 	"strings"
+	"sync"
 	"sync/atomic"
+	"time"
+	logger "github.com/500px/go-utils/chatty_logger"
 	"github.com/500px/go-utils/metrics"
-	"errors"
+	"github.com/melraidin/mysql-log-player/conn"
+	"github.com/melraidin/mysql-log-player/query"
+	"fmt"
 )
 
 var (
 	// Size of command buffer for new workers.
-	BufferSize = 20
+	BufferSize = 50
 	concurrent = int64(0)
-	NoColumnError = errors.New("no columns")
 )
 
 type Worker struct {
-	client    string
-	queryChan <-chan string
-	db        *sql.DB
-	wg        *sync.WaitGroup
-	stats     chan<- Stat
-	metrics   metrics.StatsdClient
+	Logtime0    time.Time
+	Runtime0    time.Time
+	ReplaySpeed float64
+	client      string
+	queryChan   <-chan query.Query
+	dbConns     *conn.DBConns
+	wg          *sync.WaitGroup
+	stats       chan<- Stat
+	metrics     metrics.StatsdClient
 }
 
-func NewWorker(client string, db *sql.DB, wg *sync.WaitGroup, stats chan<- Stat, metrics metrics.StatsdClient) chan<- string {
-	queryChan := make(chan string, BufferSize)
+func NewWorker(client string, logtime0, runtime0 time.Time, replaySpeed float64, dbConns *conn.DBConns, wg *sync.WaitGroup, stats chan<- Stat, statsdClient metrics.StatsdClient) chan<- query.Query {
+	queryChan := make(chan query.Query, BufferSize)
 
 	worker := Worker{
-		client:    client,
-		queryChan: queryChan,
-		db:        db,
-		wg:        wg,
-		stats:     stats,
-		metrics:   metrics,
+		Logtime0:    logtime0,
+		Runtime0:    runtime0,
+		ReplaySpeed: replaySpeed,
+		client:      client,
+		queryChan:   queryChan,
+		dbConns:     dbConns,
+		wg:          wg,
+		stats:       stats,
+		metrics:     statsdClient,
 	}
 
 	wg.Add(1)
-	go worker.Run()
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		worker.Run()
+	}()
 
 	return queryChan
 }
 
+func (w *Worker) AcquireDB() (conn.DBConn, error) {
+	timer := metrics.NewStopwatch()
+	db, err := w.dbConns.AcquireDB()
+	if err != nil {
+		return nil, fmt.Errorf("[%s] error from dbOpener: %v", w.client, err)
+	}
+
+	timer.Stop()
+	ms := timer.Ms()
+	w.metrics.Histogram("dbOpener.Open", float64(ms))
+	if ms > 100 {
+		logger.Infof("Took %d ms to open DB connection.", ms)
+	}
+
+	return db, nil
+}
+
 func (w *Worker) Run() {
+	var db conn.DBConn
+
+	var inTx = false
 	for query := range w.queryChan {
-		query = strings.TrimSpace(query)
-		if !strings.HasPrefix(strings.ToUpper(query), "SELECT") {
-			logger.Debugf("[%s] Skipping non-SELECT query: %v", w.client, query)
-			continue
-		}
-
-		active := atomic.AddInt64(&concurrent, 1)
-		w.metrics.Gauge("query_worker.concurrent", float64(active))
-		logger.Debugf("[%s] Querying: %s", w.client, query)
-
-		timer := metrics.NewStopwatch()
-		rows, err := w.db.Query(query)
-		timer.Stop()
-
-		atomic.AddInt64(&concurrent, -1)
-		logger.Debugf("[%s] Queryed", w.client)
-		if err != nil {
-			w.metrics.Histogram("query.duration", float64(timer.Ms()), "status:error")
-			w.metrics.Incr("query.count", 1, "status:error")
-			logger.Debugf("error '%v' running query: %s", err, query)
-			continue
-		}
-		w.metrics.Histogram("query.duration", float64(timer.Ms()), "status:ok")
-		w.metrics.Incr("query.count", 1, "status:ok")
-
-		if rows.Next() {
-			if strings.HasPrefix(query, "SELECT  `users`.* FROM `users` WHERE `users`.`authentication_token` =") {
-				stat := Stat{}
-				if err = extractIntColumn(rows, "id", &stat.userId); err != nil {
-					logger.Debugf("Error extracting user 'id': %v", err)
-				} else {
-					w.stats <- stat
-				}
-			} else if strings.HasPrefix(query, "SELECT  `oauth_tokens`.* FROM `oauth_tokens` WHERE `oauth_tokens`.`type` IN ('Oauth2Token')") {
-				stat := Stat{}
-				if err = extractIntColumn(rows, "user_id", &stat.userId); err != nil {
-					logger.Debugf("Error extracting 'user_id': %v", err)
-				} else {
-					w.stats <- stat
-				}
-			} else if strings.HasPrefix(query, "SELECT  `photos`.* FROM `photos` WHERE `photos`.`id` = ") {
-				stat := Stat{}
-				if err = extractIntColumn(rows, "id", &stat.photoId); err != nil {
-					logger.Debugf("Error extracting photo 'id': %v", err)
-				} else {
-					w.stats <- stat
-				}
+		w.metrics.Gauge("query.chan", float64(len(w.queryChan)), "client:" + w.client)
+		//query = strings.TrimSpace(query)
+		//if !strings.HasPrefix(strings.ToUpper(query), "SELECT") {
+		//	//logger.Debugf("[%s] Skipping non-SELECT query: %v", query)
+		//	continue
+		//}
+		if db == nil {
+			var err error
+			if db, err = w.AcquireDB(); err != nil {
+				logger.Errorf("Error from AcquireDB: %v", err)
+				continue
 			}
 		}
-		err = rows.Close()
-		if err != nil {
-			logger.Warnf("error closing rows: %v", err)
+
+		if strings.HasPrefix(query.SQL, "BEGIN") {
+			inTx = true
+		}
+
+		_ = w.doQuery(db, query)
+
+		if strings.HasPrefix(query.SQL, "COMMIT") || strings.HasPrefix(query.SQL, "ROLLBACK") {
+			inTx = false
+		}
+
+		if !inTx && len(w.queryChan) == 0 {
+			w.dbConns.ReleaseDB(db)
+			db = nil
 		}
 	}
 	w.wg.Done()
 }
 
-func extractIntColumn(rows *sql.Rows, name string, val *int32) error {
-	colNames, err := rows.Columns()
-	if err != nil {
-		return err
-	}
-	if len(colNames) == 0 {
-		return NoColumnError
-	}
-
-	values := make([]interface{}, len(colNames))
-	for i, colName := range colNames {
-		if colName == name {
-			values[i] = val
-		} else {
-			var iface interface{}
-			values[i] = &iface
+func (w *Worker) doQuery(db conn.DBConn, q query.Query) error {
+	replayTime := w.Runtime0.Add(q.Time.Sub(w.Logtime0) * 10 / time.Duration(10 * w.ReplaySpeed))
+	now := time.Now()
+	if replayTime.After(now) {
+		d := replayTime.Sub(now)
+		if d >= 2 * time.Second {
+			logger.Infof("Query 2+ seconds in future: duration=%v; sleeping %v\n", d, d/2)
+			time.Sleep(d / 2)
 		}
 	}
-	if err = rows.Scan(values...); err != nil {
+
+	//logger.Debugf("[%s] Querying: %s", w.client, query)
+	timer := metrics.NewStopwatch()
+	active := atomic.AddInt64(&concurrent, 1)
+
+	sql := q.SQL
+	rows, err := db.Query(sql)
+
+	atomic.AddInt64(&concurrent, -1)
+	timer.Stop()
+	w.metrics.Gauge("query_worker.concurrent", float64(active))
+
+	//logger.Debugf("[%s] Queryed", w.client)
+	if err != nil {
+		w.metrics.Histogram("query.duration", float64(timer.Ms()), "status:error")
+		w.metrics.Incr("query.count", 1, "status:error", "client:"+w.client)
+		//logger.Debugf("[%s] error '%v' running query: %s", w.client, err, query)
 		return err
+	}
+	w.metrics.Histogram("query.duration", float64(timer.Ms()), "status:ok")
+	w.metrics.Incr("query.count", 1, "status:ok", "client:"+w.client)
+
+	defer func() {
+		if err := rows.Close(); err != nil {
+			logger.Errorf("[%s] error closing rows: %v", w.client, err)
+		}
+	}()
+
+	row, err := rows.First()
+	if err != nil {
+		//logger.Warnf("[%s] Error '%v' in rows.First: %s", w.client, err, query)
+		return err
+	}
+
+	if strings.HasPrefix(sql, "SELECT  `users`.* FROM `users` WHERE `users`.`authentication_token` =") {
+		stat := Stat{}
+		if stat.userId, err = row.Int("id"); err != nil {
+			logger.Warnf("[%s] Error extracting user 'id': %v", w.client, err)
+		} else {
+			w.stats <- stat
+		}
+	} else if strings.HasPrefix(sql, "SELECT  `oauth_tokens`.* FROM `oauth_tokens` WHERE `oauth_tokens`.`type` IN ('Oauth2Token')") {
+		stat := Stat{}
+		if stat.userId, err = row.Int("user_id"); err != nil {
+			logger.Warnf("[%s] Error extracting 'user_id': %v", w.client, err)
+		} else {
+			w.stats <- stat
+		}
+	} else if strings.HasPrefix(sql, "SELECT  `photos`.* FROM `photos` WHERE `photos`.`id` = ") {
+		stat := Stat{}
+		if stat.photoId, err = row.Int("id"); err != nil {
+			logger.Warnf("[%s] Error extracting photo 'id': %v", w.client, err)
+		} else {
+			w.stats <- stat
+		}
 	}
 	return nil
 }

--- a/worker/query_worker.go
+++ b/worker/query_worker.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 
 	logger "github.com/500px/go-utils/chatty_logger"
+	"database/sql"
+	"strings"
 )
 
 var (
@@ -14,15 +16,17 @@ var (
 type Worker struct {
 	client    string
 	queryChan <-chan string
+	db        *sql.DB
 	wg        *sync.WaitGroup
 }
 
-func NewWorker(client string, wg *sync.WaitGroup) chan<- string {
+func NewWorker(client string, db *sql.DB, wg *sync.WaitGroup) chan<- string {
 	queryChan := make(chan string, BufferSize)
 
 	worker := Worker{
 		client:    client,
 		queryChan: queryChan,
+		db:        db,
 		wg:        wg,
 	}
 
@@ -34,7 +38,22 @@ func NewWorker(client string, wg *sync.WaitGroup) chan<- string {
 
 func (w *Worker) Run() {
 	for query := range w.queryChan {
-		logger.Debugf("[%s] Querying: %s\n", w.client, query)
+		query = strings.TrimSpace(query)
+		if !strings.HasPrefix(strings.ToUpper(query), "SELECT") {
+			logger.Debugf("[%s] Skipping non-SELECT query: %v", w.client, query)
+			continue
+		}
+		logger.Debugf("[%s] Querying: %s", w.client, query)
+
+		rows, err := w.db.Query(query)
+		if err != nil {
+			logger.Warnf("error '%v' running query: %s", err, query)
+			continue
+		}
+		err = rows.Close()
+		if err != nil {
+			logger.Warnf("error closing rows: %v", err)
+		}
 	}
 	w.wg.Done()
 }


### PR DESCRIPTION
- added `splitter` to split captured logs into 1-hour gzipped chunks
- made DBOpener, DBConn, QConn, Tx, Rows, Row interfaces for swapping in different (even native MySQL drivers)
- swap-ins using GoMySQL, MyMySQL, and Siddontang drivers
- added DataDog metrics
- pacing of queries according to a --replay-speed with fuzzy sleeps
- idle workers can release connections for use by other workers (for #clients > max connections)

Note: seems to work better (only) when run with --log=DEBUG
